### PR TITLE
Increase workflow timeout to 30 minutes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     steps:
       - name: Clone code
         uses: actions/checkout@v5


### PR DESCRIPTION
5 minutes is [not always enough](https://github.com/beeware/mobile-wheels/actions/runs/17973815451).
